### PR TITLE
Create postIt.html

### DIFF
--- a/tools/postIt.html
+++ b/tools/postIt.html
@@ -1,0 +1,1 @@
+<body id=T style=background-color:#ffff80;font-family:arial contenteditable onInput=localStorage.OS13k_PI=T.innerHTML onLoad=T.innerHTML=localStorage.OS13k_PI||''>


### PR DESCRIPTION
Post-it Notes in 165 bytes, including localStorage auto-save. Now it is possible to have both Text Editor and a Post-it Notes opened.
Some shortcuts: 
  - control-i for italic
  - control-b for bold
  - control-u for underline